### PR TITLE
spawn-npm 1.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Have an idea? Found a bug? See [how to contribute][contributing].
 If you are using this library in one of your projects, add it in this list. :sparkles:
 
 
- - [`babel-it`](https://github.com/IonicaBizau/babel-it#readme)—A cli tool to babelify your code before npm publish.
+ - [`babel-it`](https://github.com/IonicaBizau/babel-it#readme)—Babelify your code before `npm publish`.
  - [`git-module-installer`](https://github.com/IonicaBizau/git-module-installer#readme)—Clone git repositories and install their npm dependencies.
  - [`ship-release`](https://github.com/IonicaBizau/ship-release#readme)—Publish new versions on GitHub and npm with ease.
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "processes"
   ],
   "license": "MIT",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "main": "lib/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -38,6 +38,7 @@
     "src/",
     "resources/",
     "menu/",
+    "scripts/",
     "cli.js",
     "index.js"
   ]


### PR DESCRIPTION
- Updated the README.md following the new template. :memo:
- Use [`babel-it`](https://github.com/IonicaBizau/babel-it) to babelify the code, so the module is now compatible with older versions of Node.js.
